### PR TITLE
Added missing include in distribution base.

### DIFF
--- a/include/refill/distributions/distribution_base.h
+++ b/include/refill/distributions/distribution_base.h
@@ -3,6 +3,7 @@
 
 #include <glog/logging.h>
 #include <Eigen/Dense>
+#include <typeinfo>
 
 namespace refill {
 


### PR DESCRIPTION
Just added a missing `include` in `distribution_base.h`, hopefully it will now compile on jenkins.