### PR TITLE
Fixed weird halting when using eigen_catkin

### DIFF
--- a/catkin/package.xml
+++ b/catkin/package.xml
@@ -10,5 +10,5 @@ Catkin interface for Refill.
   <buildtool_depend>catkin</buildtool_depend>
   <buildtool_depend>catkin_simple</buildtool_depend>
   <depend>glog_catkin</depend>
-  <depend>eigen_catkin</depend>
+  <depend>Eigen3</depend>
 </package>


### PR DESCRIPTION
Fixed weird halting behaviour described in [eigen_catkin](https://github.com/ethz-asl/eigen_catkin/issues/16) by using `Eigen3` instead of `eigen_catkin` for catkin compilation.