### PR TITLE
Changed back to use `catkin_eigen` for compilation.

### DIFF
--- a/catkin/package.xml
+++ b/catkin/package.xml
@@ -10,5 +10,5 @@ Catkin interface for Refill.
   <buildtool_depend>catkin</buildtool_depend>
   <buildtool_depend>catkin_simple</buildtool_depend>
   <depend>glog_catkin</depend>
-  <depend>Eigen3</depend>
+  <depend>eigen_catkin</depend>
 </package>


### PR DESCRIPTION
Changed back to use `catkin_eigen` for catkin compilation, since otherwise it doesn't compile on Jenkins.