### PR TITLE
Changed to use the local Eigen installation for refill_catkin

### DIFF
--- a/catkin/CMakeLists.txt
+++ b/catkin/CMakeLists.txt
@@ -17,10 +17,15 @@ include_directories(SYSTEM
 
 # LIBRARY
 file(GLOB_RECURSE SRC_LIST "../src/*.cc")
-file(GLOB_RECURSE REMOVE_SOURCES "../src/*_test.cc")
-list(REMOVE_ITEM SRC_LIST ${REMOVE_SOURCES})
+file(GLOB_RECURSE TEST_SOURCES "../src/*_test.cc")
+list(REMOVE_ITEM SRC_LIST ${TEST_SOURCES})
 
 cs_add_library(refill ${SRC_LIST})
+
+# Tests
+cs_add_executable(refill_test ${TEST_SOURCES})
+target_link_libraries(refill_test refill ${GTEST_BOTH_LIBRARIES} -lpthread -lm)
+add_test(AllTests refill_test)
 
 cs_install()
 cs_export(

--- a/catkin/package.xml
+++ b/catkin/package.xml
@@ -10,4 +10,5 @@ Catkin interface for Refill.
   <buildtool_depend>catkin</buildtool_depend>
   <buildtool_depend>catkin_simple</buildtool_depend>
   <depend>glog_catkin</depend>
+  <depend>GTest</depend>
 </package>


### PR DESCRIPTION
I changed the refill_catkin `CMakeLists.txt` to use the local Eigen installation instead of eigen_catkin, since otherwise there can be problems with the linking, which leads to infinite loops.